### PR TITLE
Fixed state interference

### DIFF
--- a/src/main/java/me/untouchedodin0/privatemines/iterator/SchematicIterator.java
+++ b/src/main/java/me/untouchedodin0/privatemines/iterator/SchematicIterator.java
@@ -83,11 +83,15 @@ public class SchematicIterator {
                     }
                 });
 
-                mineBlocks.spawnLocation = spawn;
-                mineBlocks.corners[0] = corner1;
+                mineBlocks.spawnLocation = BlockVector3.at(spawn.getX(), spawn.getY(), spawn.getZ());
+                mineBlocks.corners[0] = BlockVector3.at(corner1.getX(), corner1.getY(), corner1.getZ());
 
                 //ignore for now
-                mineBlocks.corners[1] = corner2;
+                mineBlocks.corners[1] = BlockVector3.at(corner2.getX(), corner2.getY(), corner2.getZ());
+
+                spawn = null;
+                corner1 = null;
+                corner2 = null;
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
The first call to findRelativePoints leaves spawn, corner1 and corner2 to non-null, so subsequent calls will always skip the null condition